### PR TITLE
Update mongoose to 5.x

### DIFF
--- a/app.js
+++ b/app.js
@@ -14,7 +14,9 @@ const siteController     = require("./routes/siteController");
 const locationController = require("./routes/locationController");
 
 // Mongoose configuration
-mongoose.connect("mongodb://localhost/deploy-exercise");
+mongoose.connect("mongodb://localhost/deploy-exercise")
+  .then(() => console.log(`⚡️ connected to mongoDB`))
+  .catch(err => console.error(`💥 unable to connect to mongoDB`, err));
 
 // Middlewares configuration
 app.use(logger("dev"));

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "express-ejs-layouts": "^2.2.0",
     "express-session": "^1.15.0",
     "mongodb": "^2.2.22",
-    "mongoose": "^4.8.1",
+    "mongoose": "^5.9.16",
     "morgan": "~1.7.0"
   },
   "devDependencies": {


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/76580/93576471-386aec80-f99b-11ea-8598-40e6543e3854.png)

now using [Altas](https://www.mongodb.com/cloud/atlas), the `MONGODB_URI` starts with `mongodb+srv://` which [causes an issue](https://stackoverflow.com/a/51815241/133327) with mongoose 4.x

Upgrading to `mongoose@5` just solve the issue